### PR TITLE
sync: Senzing MCP server v1.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ claude mcp add --transport http senzing https://mcp.senzing.com/mcp
 See [SKILL.md](senzing-entity-resolution/SKILL.md) for the full skill manifest
 including tool reference, workflows, best practices, and entity resolution glossary.
 
-Verified against Senzing MCP server **v1.29.0** (2026-07). The skill's
+Verified against Senzing MCP server **v1.30.0** (2026-07). The skill's
 `version` field tracks the server version it was validated against.
 
 ## Privacy

--- a/senzing-entity-resolution/SKILL.md
+++ b/senzing-entity-resolution/SKILL.md
@@ -15,7 +15,7 @@ license: Proprietary
 compatibility: Requires Senzing MCP server (https://mcp.senzing.com/mcp) connected via claude mcp add or MCP config
 metadata:
   author: senzing
-  version: "1.29.0"
+  version: "1.30.0"
 ---
 
 # Senzing Entity Resolution — MCP Skill


### PR DESCRIPTION
Version pin to match the live server (now serving `1.30.0`).

**No skill content changes.** v1.30.0 changes served response-schema *data* (7 schemas → 13; ~29 → 1,144 fields) and migrates the MCP SDK to rmcp 2.2, but the **tool surface is unchanged** — every tool's `inputSchema` was diffed against production with **zero drift across all 13 tools**, including the quoted-token sets downstream clients derive their enums from.

Upstream: [999gz-Ops/sz-mcp-coworker#145](https://github.com/999gz-Ops/sz-mcp-coworker/pull/145)