### PR TITLE
chore: sync to MCP server v1.32.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ claude mcp add --transport http senzing https://mcp.senzing.com/mcp
 See [SKILL.md](senzing-entity-resolution/SKILL.md) for the full skill manifest
 including tool reference, workflows, best practices, and entity resolution glossary.
 
-Verified against Senzing MCP server **v1.31.0** (2026-07). The skill's
+Verified against Senzing MCP server **v1.32.3** (2026-07). The skill's
 `version` field tracks the server version it was validated against.
 
 ## Privacy

--- a/senzing-entity-resolution/SKILL.md
+++ b/senzing-entity-resolution/SKILL.md
@@ -15,7 +15,7 @@ license: Proprietary
 compatibility: Requires Senzing MCP server (https://mcp.senzing.com/mcp) connected via claude mcp add or MCP config
 metadata:
   author: senzing
-  version: "1.31.0"
+  version: "1.32.3"
 ---
 
 # Senzing Entity Resolution — MCP Skill


### PR DESCRIPTION
Bumps the pinned MCP server version 1.31.0 → 1.32.3.

**Version-only.** v1.32.3 changed no tool surface — the new fields (`content_elided`, `source_download_url`, `download_url_max_records`) are *response* fields, not declared parameters — so the skill's grounding content needs no edits.

**Supersedes #6** (the auto-sync PR for v1.32.2, never merged). This repo had drifted two releases behind; going straight to 1.32.3 rather than merging the stale intermediate.

Verified live: `mcp.senzing.com/.well-known/agent-card.json` reports `1.32.3`, post-deploy smoke passed.