### PR TITLE
chore: sync to MCP server v1.32.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ claude mcp add --transport http senzing https://mcp.senzing.com/mcp
 See [SKILL.md](senzing-entity-resolution/SKILL.md) for the full skill manifest
 including tool reference, workflows, best practices, and entity resolution glossary.
 
-Verified against Senzing MCP server **v1.32.3** (2026-07). The skill's
+Verified against Senzing MCP server **v1.32.4** (2026-08). The skill's
 `version` field tracks the server version it was validated against.
 
 ## Privacy

--- a/senzing-entity-resolution/SKILL.md
+++ b/senzing-entity-resolution/SKILL.md
@@ -15,7 +15,7 @@ license: Proprietary
 compatibility: Requires Senzing MCP server (https://mcp.senzing.com/mcp) connected via claude mcp add or MCP config
 metadata:
   author: senzing
-  version: "1.32.3"
+  version: "1.32.4"
 ---
 
 # Senzing Entity Resolution — MCP Skill


### PR DESCRIPTION
Bumps the pinned MCP server version 1.32.3 → 1.32.4.

**Version-only.** v1.32.4 changed behaviour, response fields and wording — no tool added, removed or renamed, no declared parameter changed — so the skill's grounding content needs no edits.

**Verified live before opening this:** `mcp.senzing.com/.well-known/agent-card.json` reports `1.32.4`, both post-deploy smoke jobs passed, MCP Registry published, no rollback.