### PR TITLE
chore: sync to MCP server v1.32.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ claude mcp add --transport http senzing https://mcp.senzing.com/mcp
 See [SKILL.md](senzing-entity-resolution/SKILL.md) for the full skill manifest
 including tool reference, workflows, best practices, and entity resolution glossary.
 
-Verified against Senzing MCP server **v1.32.4** (2026-08). The skill's
+Verified against Senzing MCP server **v1.32.5** (2026-08). The skill's
 `version` field tracks the server version it was validated against.
 
 ## Privacy

--- a/senzing-entity-resolution/SKILL.md
+++ b/senzing-entity-resolution/SKILL.md
@@ -15,7 +15,7 @@ license: Proprietary
 compatibility: Requires Senzing MCP server (https://mcp.senzing.com/mcp) connected via claude mcp add or MCP config
 metadata:
   author: senzing
-  version: "1.32.4"
+  version: "1.32.5"
 ---
 
 # Senzing Entity Resolution — MCP Skill


### PR DESCRIPTION
Signed re-do of the version-sync bump (auto-generated #9 had an unsigned commit blocked by require-signed-commits). Bumps README + SKILL.md to track MCP server v1.32.5. Supersedes #9.